### PR TITLE
Enables compiling and running with maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,5 +34,33 @@
 	</dependency>
 	
   </dependencies>
+
+  <properties>
+	<maven.compiler.source>1.8</maven.compiler.source>
+	<maven.compiler.target>1.8</maven.compiler.target>
+ </properties>
+
+ <build>
+	<plugins>
+	    	<plugin>
+	    		<!-- config for jar -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<archive>
+						<index>true</index>
+						<manifest>
+							<addClasspath>true</addClasspath>
+							<mainClass>verti.roguelike.RoguelikeEngine</mainClass>
+							</manifest>
+						<manifestEntries>
+							<mode>development</mode>
+					</manifestEntries>
+				</archive>
+			</configuration>
+		</plugin>
+	</plugins>
+ </build>
   
 </project>


### PR DESCRIPTION
These were the pom changes required to compile and run verti-roguelike locally with maven, rather than via an IDE project.